### PR TITLE
Clear display before showing new text

### DIFF
--- a/badge_firmata.ino
+++ b/badge_firmata.ino
@@ -689,6 +689,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
       break;
     case NERVES_OLED_WRITE:
       {
+        TickerOLED::clearDisplay();
         TickerOLED::setTextXY(3, 0);
         TickerOLED::drawBitmap(NervesSmall, sizeof(NervesSmall));
         TickerOLED::setTicker((const char *) argv, argc); //Print the String


### PR DESCRIPTION
After loading and showing the first text message, part of the large logo is still displayed when the next text message is displayed.
